### PR TITLE
Improve spectral classes

### DIFF
--- a/test/test_spectral_fft.py
+++ b/test/test_spectral_fft.py
@@ -37,7 +37,7 @@ def test_welch():
 
     expected = xr.DataArray(np.stack([expected_data], 0),
                             coords=[expected_times, expected_freqs, data._data.columns],
-                            dims=['time', 'freq', 'space'])
+                            dims=['time', 'frequency', 'space'])
 
     xr.testing.assert_allclose(node.o.data, expected, rtol=1e-06)
 
@@ -56,3 +56,12 @@ def test_fft_nfft():
     node.i.data = data.next(10)
     node.update()
     assert node._nfft == 10
+
+def test_fft_nfft():
+    data.reset()
+    node = FFT(return_onesided=True)
+    node.i.data = data.next(10)
+    node.i.meta = {'rate': 5}
+    node.update()
+    assert node._nfft == 10
+    assert node._rate == 5

--- a/timeflux_dsp/nodes/spectral.py
+++ b/timeflux_dsp/nodes/spectral.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 import xarray as xr
+import math
 from scipy.signal import welch
 from scipy.signal.spectral import fftpack
 from timeflux.core.node import Node
@@ -17,9 +18,9 @@ class FFT(Node):
 
     Example:
 
-        In this exemple, we simulate a white noise and we apply FFT:
+        In this example, we simulate a white noise and we apply FFT:
 
-         * ``fs`` = `10.0`
+         * ``rate`` = `10.0`
          * ``nfft`` = `5`
          * ``return_onesided`` = `False`
 
@@ -35,16 +36,16 @@ class FFT(Node):
 
         self.o.data::
 
-            xarray.DataArray (times: 1, freqs: 5, space: 3)
+            xarray.DataArray (times: 1, frequency: 5, space: 3)
             array([[[ 3.043119+0.j      ,  2.458294+0.j      ,  3.47464 +0.j      ],
                     [-0.252884+0.082233j, -0.06265 -1.098709j,  0.29353 +0.478287j],
                     [-0.805843+0.317437j,  0.188256+0.146341j,  0.151515-0.674376j],
                     [-0.805843-0.317437j,  0.188256-0.146341j,  0.151515+0.674376j],
                     [-0.252884-0.082233j, -0.06265 +1.098709j,  0.29353 -0.478287j]]])
             Coordinates:
-              * times    (times) datetime64[ns] 2018-01-01T00:00:00.396560186
-              * freqs    (freqs) float64 0.0 2.0 4.0 -4.0 -2.0
-              * space    (space) object 'A' 'B' 'C'
+              * times     (times) datetime64[ns] 2018-01-01T00:00:00.396560186
+              * frequency (frequency) float64 0.0 2.0 4.0 -4.0 -2.0
+              * space     (space) object 'A' 'B' 'C'
 
     Notes:
        This node should be used after a buffer.
@@ -54,7 +55,7 @@ class FFT(Node):
 
     """
 
-    def __init__(self, fs=1.0, nfft=None, return_onesided=True):
+    def __init__(self, rate=None, nfft=None, return_onesided=True, interpolation=True):
         """
             Args:
                 fs (float): Nominal sampling rate of the input data.
@@ -63,36 +64,50 @@ class FFT(Node):
                                               If `False` return a two-sided spectrum.
                                               (Note that for complex data, a two-sided spectrum is always returned.)
                                               Default: `True`.
+                interpolation (bool|dict): How to interpolate NaN values in the input using Pandas interpolate.
         """
 
-        self._fs = fs
+        self._fixed_rate = rate
+        self._rate = rate
+        self._fixed_nfft = int(nfft)
         self._nfft = nfft
+
+        self._interpolation = {
+            'method': 'time',
+            'limit': 10,
+        }
+        if type(interpolation) is dict:
+            self._interpolate = True
+            self._interpolation = {**self._interpolation, **interpolation}
+        else:
+            self._interpolate = interpolation
+
         if return_onesided:
             self._sides = 'onesided'
         else:
             self._sides = 'twosided'
-        if self._nfft is not None:
+        if self._nfft is not None and self._rate is not None:
             self._set_freqs()
 
     def _check_nfft(self):
 
         # Check validity of nfft at first chunk
-        if self._nfft is None:
+        if self._fixed_nfft is None:
             self.logger.debug("nfft := length of the chunk ")
             self._nfft = self.i.data.shape[0]
             self._set_freqs()
-        elif self._nfft < self.i.data.shape[0]:
-            raise ValueError('nfft must be greater than or equal to length of chunk.')
+        elif self._fixed_nfft > self.i.data.shape[0]:
+            raise ValueError('nfft must be less than or equal to length of chunk.')
         else:
-            self._nfft = int(self._nfft)
+            self.o.data = self.o.data.tail(self._fixed_nfft)
 
     def _set_freqs(self):
 
         # Set freqs indexes
         if self._sides == 'onesided':
-            self._freqs = np.fft.rfftfreq(self._nfft, 1 / self._fs)
+            self._freqs = np.fft.rfftfreq(self._nfft, 1 / self._rate)
         else:
-            self._freqs = fftpack.fftfreq(self._nfft, 1 / self._fs)
+            self._freqs = fftpack.fftfreq(self._nfft, 1 / self._rate)
 
     def update(self):
 
@@ -104,17 +119,26 @@ class FFT(Node):
             return
 
         # At this point, we are sure that we have some data to process
-        self._check_nfft()
+        if self._rate is None:
+            if 'rate' in self.i.meta:
+                self._rate = self.i.meta['rate']
+            else:
+                self._rate = 1.0
         self.o.data = self.i.data
+        self._check_nfft()
+
+        # FFT cannot handle NaNs and will return NaN if a single input value is NaN.
+        if self._interpolate:
+            self.o.data = self.o.data.interpolate(**self._interpolation)
+
         if self._sides == 'twosided':
             func = fftpack.fft
         else:
-            self.o.data = self.o.data.apply(lambda x: x.real)
             func = np.fft.rfft
         values = func(self.o.data.values.T, n=self._nfft).T
         self.o.data = xr.DataArray(np.stack([values], 0),
                                    coords=[[self.o.data.index[-1]], self._freqs, self.o.data.columns],
-                                   dims=['time', 'freq', 'space'])
+                                   dims=['time', 'frequency', 'space'])
 
 
 class Welch(Node):
@@ -142,7 +166,7 @@ class Welch(Node):
 
         node.o.data::
 
-            <xarray.DataArray (time: 1, freq: 13, space: 3)>
+            <xarray.DataArray (time: 1, frequency: 13, space: 3)>
             array([[[2.823924e-02, 1.087382e-01, 1.153163e-01],
                 [1.703466e-01, 6.048703e-01, 6.310628e-01],
                 ...            ...           ...
@@ -150,9 +174,9 @@ class Welch(Node):
                 [1.239551e-03, 7.412518e-04, 9.863335e-04],
                 [5.382880e-04, 4.999334e-04, 4.702757e-04]]])
             Coordinates:
-                * time     (time) datetime64[ns] 1970-01-01T00:00:01.190000
-                * freq     (freq) float64 0.0 4.167 8.333 12.5 16.67 ... 37.5 41.67 45.83 50.0
-                * space    (space) object 'a' 'b' 'c'
+                * time      (time) datetime64[ns] 1970-01-01T00:00:01.190000
+                * frequency (frequency) float64 0.0 4.167 8.333 12.5 16.67 ... 37.5 41.67 45.83 50.0
+                * space     (space) object 'a' 'b' 'c'
 
         Notes:
 
@@ -191,7 +215,7 @@ class Welch(Node):
             self.logger.debug('noverlap := nperseg/2 := {noverlap}'.format(noverlap=self._kwargs['noverlap']))
 
     def _check_nfft(self):
-        # Check validity of nfft at first chun
+        # Check validity of nfft at first chunk
         if not all(i <= len(self.i.data) for i in [self._kwargs[k] for k in ['nfft', 'nperseg', 'noverlap']]):
             raise ValueError('nfft, noverlap and nperseg must be greater than or equal to length of chunk.')
         else:
@@ -246,16 +270,18 @@ class Bands(Node):
 
     """
 
-    def __init__(self, bands=None, relative=False):
+    def __init__(self, bands=None, relative=False, amplitude=True):
 
         """
         Args:
            bands (dict): Define the band to extract given its name and its range.
                          An output port will be created with the given names as suffix.
-
+            relative (bool): Whether the bands values should be expressed as absolute values, or as a proportion of the sum of the whole spectrum. Default: False.
+            amplitude (bool): Whether to return the magnitude as a real number representing the amplitude or a complex number representing both amplitude and phase. Default: True.
         """
         bands = bands or {'delta': [1, 4], 'theta': [4, 8], 'alpha': [8, 12], 'beta': [12, 30]}
         self._relative = relative
+        self._amplitude = amplitude
         self._bands = []
         for band_name, band_range in bands.items():
             self._bands.append(dict(port=getattr(self, 'o_' + band_name),
@@ -277,7 +303,8 @@ class Bands(Node):
                 tot_power = self.i.data.sum('frequency').values
                 tot_power[tot_power == 0.0] = 1
                 band_power /= tot_power
-
             band['port'].data = pd.DataFrame(columns=self.i.data.space.values, index=self.i.data.time.values,
                                              data=band_power)
+            if self._amplitude:
+                band['port'].data = abs(band['port'].data)
             band['port'].meta = {**(self.i.meta or {}), **band['meta']}

--- a/timeflux_dsp/nodes/spectral.py
+++ b/timeflux_dsp/nodes/spectral.py
@@ -69,8 +69,8 @@ class FFT(Node):
 
         self._fixed_rate = rate
         self._rate = rate
-        self._fixed_nfft = int(nfft)
-        self._nfft = nfft
+        self._nfft = None if nfft is None else int(nfft)
+        self._fixed_nfft = self._nfft
 
         self._interpolation = {
             'method': 'time',

--- a/timeflux_dsp/nodes/spectral.py
+++ b/timeflux_dsp/nodes/spectral.py
@@ -88,7 +88,7 @@ class FFT(Node):
             self._nfft = self.i.data.shape[0]
         elif self._nfft != self.i.data.shape[0]:
             # np & scipy will pad/truncate the input as necessary, but this may not be desired.
-            self.logger.debug("FFT input chunk has length {} but nfft is {}".format(self.i.data.shape[0], self._nfft))
+            self.logger.warning("FFT input chunk has length {} but nfft is {}".format(self.i.data.shape[0], self._nfft))
 
     def _set_freqs(self):
 
@@ -112,7 +112,7 @@ class FFT(Node):
             if 'rate' in self.i.meta:
                 self._rate = self.i.meta['rate']
             else:
-                self.logger.debug("FFT using default sampling rate of 1; you should specify the rate explicitly or by meta.")
+                self.logger.warning("FFT using default sampling rate of 1; you should specify the rate explicitly or by meta.")
                 self._rate = 1.0
         self.o.data = self.i.data
         self._check_nfft()

--- a/timeflux_dsp/nodes/spectral.py
+++ b/timeflux_dsp/nodes/spectral.py
@@ -66,8 +66,6 @@ class FFT(Node):
                 nfft (int|None): Length of the Fourier transform. Default: length of the chunk.
                 return_onesided (bool): If `True`, return a one-sided spectrum for real data.
                                               If `False` return a two-sided spectrum.
-                                              (Note that for complex data, a two-sided spectrum is always returned.)
-                                              Default: `True`.
         """
 
         self._rate = rate


### PR DESCRIPTION
This PR makes various inter-related fixes and improvements (probably too many) to the spectral classes:

* Fix #8 for FFT (but not for Welch yet)
* Allow FFT nfft to vary dynamically dependent on input length
* Allow FFT rate to come from meta
* Rename FFT 'fs' parameter to 'rate' for consistency with Welch and rest of timeflux
* Fix bug in FFT where one-sided (the default) was not working because pd.Series has no attribute 'real' in pd.apply
* Don't bother converting dataframe to real numbers because https://docs.scipy.org/doc/numpy/reference/generated/numpy.fft.rfft.html#numpy.fft.rfft) says: "If the input a contains an imaginary part, it is silently discarded."
 * Use same dimension "frequency" in FFT, Welch and Bands so that Bands can come after an FFT.
* Convert Bands output to amplitude real number.
* Allow FFT to interpolate NaNs, so that a whole 20 second window is not discarded because of a single NaN
* Document relative parameter for Bands
