### PR TITLE
Improve tests for filters

### DIFF
--- a/test/test_filters_digital.py
+++ b/test/test_filters_digital.py
@@ -19,7 +19,8 @@ def rate():
 @pytest.fixture(scope="module")
 def generator(rate):
     """Create object to mimic data streaming """
-    # Signal of 300 points (sum of two sinus at 0.5 Hz  and 10 Hz) sampled at 50 kHz.
+    # Signal of 300 points (sum of two sinus at 0.5 Hz  and 10 Hz)
+    # sampled at 50 kHz.
 
     n = int(rate * 30)  # 30 seconds of data
     m = 3
@@ -34,7 +35,8 @@ def generator(rate):
     original = tm.makeTimeDataFrame(n, freq="L").rename(
         columns={"A": "noise", "B": "carrier", "C": "signal",}
     )
-    original.index = original.index[0] + pd.to_timedelta(np.arange(n) / rate, unit="s")
+    original.index = original.index[0] + \
+        pd.to_timedelta(np.arange(n) / rate, unit="s")
     t = (original.index - original.index[0]) / np.timedelta64(1, "s")
     original["noise"] = a_noise * np.sin(2 * np.pi * f_noise * t)
     original["carrier"] = a_carrier * np.sin(2 * np.pi * f_carrier * t)
@@ -47,13 +49,15 @@ def generator(rate):
 # -----------------------------------------------------------------------------
 # Test that filtering online (chunk by chunk) is the same as filtering offline
 # -----------------------------------------------------------------------------
-def test_cascade_iirfilter(generator):
+@pytest.mark.parametrize("chunk_size", [1, 5, 10, 50])
+def test_cascade_iirfilter(generator, chunk_size):
     """ Test IIRFilter cascade  """
     rate = generator._rate
-    cutoff_hz = 3
+    cutoff_hz, order = 3, 3
+
     # create filter
     node_iir = IIRFilter(
-        rate=rate, frequencies=[cutoff_hz], filter_type="lowpass", order=3
+        rate=rate, frequencies=[cutoff_hz], filter_type="lowpass", order=order
     )
 
     # Filter online (chunk by chunk)
@@ -61,7 +65,7 @@ def test_cascade_iirfilter(generator):
     # reset the data streamer
     generator.reset()
     looper = Looper(node=node_iir, generator=generator)
-    cascade_output, _ = looper.run(chunk_size=5)
+    cascade_output, _ = looper.run(chunk_size=chunk_size)
 
     # Filter offline (whole data)
     # --------------
@@ -79,23 +83,28 @@ def test_cascade_iirfilter(generator):
     )
     np.testing.assert_array_almost_equal(node_iir._sos, expected_sos)
 
-    # assert signal filtered offline and online are the same after the warmup period.
-    order = 3
+    # assert signals filtered offline and online are the same after the warmup
+    # period
     warmup = 100 * (order) / (node_iir._rate)
     np.testing.assert_array_almost_equal(
         continuous_output.iloc[int(warmup * node_iir._rate) :].values,
         cascade_output.iloc[int(warmup * node_iir._rate) :].values,
-        3,
+        6,
     )
 
 
-def test_cascade_firfilter(generator):
+@pytest.mark.parametrize("chunk_size", [1, 5, 10, 50])
+def test_cascade_firfilter(generator, chunk_size):
     """ Test FIRFilter"""
     rate = generator._rate
 
     # create the filter
     node_fir = FIRFilter(
-        rate=rate, columns="all", order=20, frequencies=[3, 4], filter_type="lowpass"
+        rate=rate,
+        columns="all",
+        order=20,
+        frequencies=[3, 4],
+        filter_type="lowpass",
     )
     expected_coeffs = np.array(
         [
@@ -127,7 +136,7 @@ def test_cascade_firfilter(generator):
     # reset the data streamer
     generator.reset()
     looper = Looper(node=node_fir, generator=generator)
-    cascade_output, cascade_meta = looper.run(chunk_size=5)
+    cascade_output, cascade_meta = looper.run(chunk_size=chunk_size)
 
     # Filter offline (whole data)
     # --------------
@@ -147,12 +156,12 @@ def test_cascade_firfilter(generator):
     # assert filters coeffs are correct
     np.testing.assert_array_almost_equal(node_fir._coeffs, expected_coeffs)
 
-    # assert signal filtered offline and online are the same
+    # assert signals filtered offline and online are the same
     warmup = delay * 2
-    pd.testing.assert_frame_equal(
+    np.testing.assert_array_almost_equal(
         continuous_output.iloc[int(warmup * node_fir._rate) :],
         cascade_output.iloc[int(warmup * node_fir._rate) :],
-        check_less_precise=3,
+        6,
     )
 
     # correct for induced delay
@@ -167,9 +176,12 @@ def test_bandpass_power_ratio():
     n = int(rate * 30)  # 30 seconds of data
     lo, hi = 10, 20
     original = tm.makeTimeDataFrame(n)
-    original.index = original.index[0] + pd.to_timedelta(np.arange(n) / rate, unit="s")
+    original.index = original.index[0] \
+        + pd.to_timedelta(np.arange(n) / rate, unit="s")
 
-    node_iir = IIRFilter(rate=rate, frequencies=[lo, hi], filter_type="bandpass")
+    node_iir = IIRFilter(
+        rate=rate, frequencies=[lo, hi], filter_type="bandpass"
+    )
     node_fir = FIRFilter(
         rate=rate, frequencies=[lo, hi], filter_type="bandpass", order=rate
     )
@@ -223,7 +235,11 @@ def test_custom_sos(generator):
     # sos does not have valid form
     with pytest.raises(ValueError):
         node_iir_custom2 = IIRFilter(
-            rate=rate, order=None, frequencies=None, filter_type=None, sos=sos[:, :5]
+            rate=rate,
+            order=None,
+            frequencies=None,
+            filter_type=None,
+            sos=sos[:, :5],
         )
         node_iir_custom2.i.data = chunk.copy()
         node_iir_custom2.update()


### PR DESCRIPTION
This PR:
- adds different chunk sizes for tests on filters;
- adds tests for offline filtering with respect Scipy.

New tests are ok, but I don't understand why a warmup period is needed.